### PR TITLE
tests: Ready condition rename for wafv2-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.51.21 h1:UrT6JC9R9PkYYXDZBV0qDKTualMr+bfK2eboTknMgbs=
 github.com/aws/aws-sdk-go v1.51.21/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -86,6 +84,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.51.0 h1:dgf25lfg5r1kjJtHzdbNrMtQVloYn77WLYi1X41NXhw=
+github.com/gustavodiaz7722/ack-runtime v0.51.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@62b132c217bd912960e268962664c545a6fa824d
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@075991b980ffbc9177f0427270be707359240f89

--- a/test/e2e/tests/test_ip_set.py
+++ b/test/e2e/tests/test_ip_set.py
@@ -71,7 +71,7 @@ class TestIPSet:
         ref, _ = simple_ip_set
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 

--- a/test/e2e/tests/test_rule_group.py
+++ b/test/e2e/tests/test_rule_group.py
@@ -105,7 +105,7 @@ class TestRuleGroup:
         ref, _ = simple_rule_group
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 
@@ -155,7 +155,7 @@ class TestRuleGroup:
         ref, _ = nested_statement_rule_group
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 

--- a/test/e2e/tests/test_web_acl.py
+++ b/test/e2e/tests/test_web_acl.py
@@ -159,7 +159,7 @@ class TestWebACL:
         ref, _ = simple_web_acl
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 
@@ -209,7 +209,7 @@ class TestWebACL:
         ref, _ = nested_statement_web_acl
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 
@@ -245,7 +245,7 @@ class TestWebACL:
         ref, _ = web_acl_with_logging
 
         time.sleep(CREATE_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         cr = k8s.get_resource(ref)
 


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.