### PR TITLE
feat[WebACL]: add support for Capacity and ApplicationIntegrationURL

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-03-11T22:04:26Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
-api_directory_checksum: ce7946ade203ed47906d8cb4cc7bf3f0440eebbd
+  build_date: "2026-04-04T00:09:13Z"
+  build_hash: a9e2ceaadfc00a742e2ea2b6d6c68348f03e52a5
+  go_version: go1.26.0
+  version: v0.58.0-3-ga9e2cea
+api_directory_checksum: b76e1cbc62fb6cc6a9c5bd0fd0a1c31fd6c701c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 079f73d1d44451069e7252d2834ba81b8c6f5045
+  file_checksum: d67c506d08a923fb3690a1d7b1352f61332d63dc
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -89,6 +89,16 @@ resources:
         template_path: hooks/common/sdk_file_end.go.tpl
   WebACL:
     fields:
+      Capacity:
+        is_read_only: true
+        from:
+          operation: GetWebACL
+          path: WebACL.Capacity
+      ApplicationIntegrationURL:
+        is_read_only: true
+        from:
+          operation: GetWebACL
+          path: ApplicationIntegrationURL
       Name:
         is_primary_key: true
         is_immutable: true

--- a/apis/v1alpha1/web_acl.go
+++ b/apis/v1alpha1/web_acl.go
@@ -139,6 +139,28 @@ type WebACLStatus struct {
 	// resource
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	// The URL to use in SDK integrations with Amazon Web Services managed rule
+	// groups. For example, you can use the integration SDKs with the account takeover
+	// prevention managed rule group AWSManagedRulesATPRuleSet and the account creation
+	// fraud prevention managed rule group AWSManagedRulesACFPRuleSet. This is only
+	// populated if you are using a rule group in your web ACL that integrates with
+	// your applications in this way. For more information, see WAF client application
+	// integration (https://docs.aws.amazon.com/waf/latest/developerguide/waf-application-integration.html)
+	// in the WAF Developer Guide.
+	// +kubebuilder:validation:Optional
+	ApplicationIntegrationURL *string `json:"applicationIntegrationURL,omitempty"`
+	// The web ACL capacity units (WCUs) currently being used by this web ACL.
+	//
+	// WAF uses WCUs to calculate and control the operating resources that are used
+	// to run your rules, rule groups, and web ACLs. WAF calculates capacity differently
+	// for each rule type, to reflect the relative cost of each rule. Simple rules
+	// that cost little to run use fewer WCUs than more complex rules that use more
+	// processing power. Rule group capacity is fixed at creation, which helps users
+	// plan their web ACL WCU usage when they use a rule group. For more information,
+	// see WAF web ACL capacity units (WCU) (https://docs.aws.amazon.com/waf/latest/developerguide/aws-waf-capacity-units.html)
+	// in the WAF Developer Guide.
+	// +kubebuilder:validation:Optional
+	Capacity *int64 `json:"capacity,omitempty"`
 	// The unique identifier for the web ACL. This ID is returned in the responses
 	// to create and list commands. You provide it to operations like update and
 	// delete.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -4062,6 +4062,16 @@ func (in *WebACLStatus) DeepCopyInto(out *WebACLStatus) {
 			}
 		}
 	}
+	if in.ApplicationIntegrationURL != nil {
+		in, out := &in.ApplicationIntegrationURL, &out.ApplicationIntegrationURL
+		*out = new(string)
+		**out = **in
+	}
+	if in.Capacity != nil {
+		in, out := &in.Capacity, &out.Capacity
+		*out = new(int64)
+		**out = **in
+	}
 	if in.ID != nil {
 		in, out := &in.ID, &out.ID
 		*out = new(string)

--- a/config/crd/bases/wafv2.services.k8s.aws_webacls.yaml
+++ b/config/crd/bases/wafv2.services.k8s.aws_webacls.yaml
@@ -4344,6 +4344,31 @@ spec:
                 - ownerAccountID
                 - region
                 type: object
+              applicationIntegrationURL:
+                description: |-
+                  The URL to use in SDK integrations with Amazon Web Services managed rule
+                  groups. For example, you can use the integration SDKs with the account takeover
+                  prevention managed rule group AWSManagedRulesATPRuleSet and the account creation
+                  fraud prevention managed rule group AWSManagedRulesACFPRuleSet. This is only
+                  populated if you are using a rule group in your web ACL that integrates with
+                  your applications in this way. For more information, see WAF client application
+                  integration (https://docs.aws.amazon.com/waf/latest/developerguide/waf-application-integration.html)
+                  in the WAF Developer Guide.
+                type: string
+              capacity:
+                description: |-
+                  The web ACL capacity units (WCUs) currently being used by this web ACL.
+
+                  WAF uses WCUs to calculate and control the operating resources that are used
+                  to run your rules, rule groups, and web ACLs. WAF calculates capacity differently
+                  for each rule type, to reflect the relative cost of each rule. Simple rules
+                  that cost little to run use fewer WCUs than more complex rules that use more
+                  processing power. Rule group capacity is fixed at creation, which helps users
+                  plan their web ACL WCU usage when they use a rule group. For more information,
+                  see WAF web ACL capacity units (WCU) (https://docs.aws.amazon.com/waf/latest/developerguide/aws-waf-capacity-units.html)
+                  in the WAF Developer Guide.
+                format: int64
+                type: integer
               conditions:
                 description: |-
                   All CRs managed by ACK have a common `Status.Conditions` member that

--- a/generator.yaml
+++ b/generator.yaml
@@ -89,6 +89,16 @@ resources:
         template_path: hooks/common/sdk_file_end.go.tpl
   WebACL:
     fields:
+      Capacity:
+        is_read_only: true
+        from:
+          operation: GetWebACL
+          path: WebACL.Capacity
+      ApplicationIntegrationURL:
+        is_read_only: true
+        from:
+          operation: GetWebACL
+          path: ApplicationIntegrationURL
       Name:
         is_primary_key: true
         is_immutable: true

--- a/helm/crds/wafv2.services.k8s.aws_webacls.yaml
+++ b/helm/crds/wafv2.services.k8s.aws_webacls.yaml
@@ -4344,6 +4344,31 @@ spec:
                 - ownerAccountID
                 - region
                 type: object
+              applicationIntegrationURL:
+                description: |-
+                  The URL to use in SDK integrations with Amazon Web Services managed rule
+                  groups. For example, you can use the integration SDKs with the account takeover
+                  prevention managed rule group AWSManagedRulesATPRuleSet and the account creation
+                  fraud prevention managed rule group AWSManagedRulesACFPRuleSet. This is only
+                  populated if you are using a rule group in your web ACL that integrates with
+                  your applications in this way. For more information, see WAF client application
+                  integration (https://docs.aws.amazon.com/waf/latest/developerguide/waf-application-integration.html)
+                  in the WAF Developer Guide.
+                type: string
+              capacity:
+                description: |-
+                  The web ACL capacity units (WCUs) currently being used by this web ACL.
+
+                  WAF uses WCUs to calculate and control the operating resources that are used
+                  to run your rules, rule groups, and web ACLs. WAF calculates capacity differently
+                  for each rule type, to reflect the relative cost of each rule. Simple rules
+                  that cost little to run use fewer WCUs than more complex rules that use more
+                  processing power. Rule group capacity is fixed at creation, which helps users
+                  plan their web ACL WCU usage when they use a rule group. For more information,
+                  see WAF web ACL capacity units (WCU) (https://docs.aws.amazon.com/waf/latest/developerguide/aws-waf-capacity-units.html)
+                  in the WAF Developer Guide.
+                format: int64
+                type: integer
               conditions:
                 description: |-
                   All CRs managed by ACK have a common `Status.Conditions` member that

--- a/pkg/resource/web_acl/hooks.go
+++ b/pkg/resource/web_acl/hooks.go
@@ -347,6 +347,9 @@ func (rm *resourceManager) setResourceAdditionalFields(
 	if resp.LockToken != nil {
 		ko.Status.LockToken = resp.LockToken
 	}
+	if resp.ApplicationIntegrationURL != nil {
+		ko.Status.ApplicationIntegrationURL = resp.ApplicationIntegrationURL
+	}
 
 	if err := rm.setOutputRulesNestedStatements(ko.Spec.Rules, resp); err != nil {
 		return err

--- a/pkg/resource/web_acl/sdk.go
+++ b/pkg/resource/web_acl/sdk.go
@@ -122,6 +122,7 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Spec.AssociationConfig = nil
 	}
+	ko.Status.Capacity = &resp.WebACL.Capacity
 	if resp.WebACL.CaptchaConfig != nil {
 		f3 := &svcapitypes.CaptchaConfig{}
 		if resp.WebACL.CaptchaConfig.ImmunityTimeProperty != nil {

--- a/test/e2e/tests/test_web_acl.py
+++ b/test/e2e/tests/test_web_acl.py
@@ -171,8 +171,16 @@ class TestWebACL:
         assert "id" in cr["status"]
         web_acl_id = cr["status"]["id"]
 
-        latest = web_acl.get(web_acl_name, web_acl_id)
-        assert latest is not None
+        # Verify capacity and applicationIntegrationURL match AWS
+        aws_resp = web_acl.get(web_acl_name, web_acl_id)
+        assert aws_resp is not None
+        assert "capacity" in cr["status"]
+        assert cr["status"]["capacity"] == aws_resp["WebACL"]["Capacity"]
+        if "ApplicationIntegrationURL" in aws_resp:
+            assert "applicationIntegrationURL" in cr["status"]
+            assert cr["status"]["applicationIntegrationURL"] == aws_resp["ApplicationIntegrationURL"]
+
+        latest = aws_resp["WebACL"]
         assert "Rules" in latest
         assert "Description" in latest
         rules = latest["Rules"]
@@ -190,7 +198,7 @@ class TestWebACL:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_SECONDS)
 
-        latest = web_acl.get(web_acl_name, web_acl_id)
+        latest = web_acl.get_web_acl(web_acl_name, web_acl_id)
         assert latest is not None
         assert "Rules" in latest
         assert "Description" in latest
@@ -221,7 +229,7 @@ class TestWebACL:
         assert "id" in cr["status"]
         web_acl_id = cr["status"]["id"]
 
-        latest = web_acl.get(web_acl_name, web_acl_id)
+        latest = web_acl.get_web_acl(web_acl_name, web_acl_id)
         assert latest is not None
         assert "Rules" in latest
         rules = latest["Rules"]
@@ -257,7 +265,7 @@ class TestWebACL:
         assert "id" in cr["status"]
         web_acl_id = cr["status"]["id"]
 
-        latest = web_acl.get(web_acl_name, web_acl_id)
+        latest = web_acl.get_web_acl(web_acl_name, web_acl_id)
         assert latest is not None
         
         # Check logging configuration is present

--- a/test/e2e/web_acl.py
+++ b/test/e2e/web_acl.py
@@ -42,7 +42,7 @@ def wait_until_deleted(
             pytest.fail("Timed out waiting for WebACL to be " "deleted in WAFv2 API")
         time.sleep(interval_seconds)
 
-        latest = get(name, id)
+        latest = get_web_acl(name, id)
         if latest is None:
             break
 
@@ -52,9 +52,22 @@ def get(
     id: str,
     scope: str = "REGIONAL",
 ):
+    """Returns the full GetWebACL response including top-level fields
+    like ApplicationIntegrationURL."""
     c = boto3.client("wafv2")
     try:
-        resp = c.get_web_acl(Name=name, Id=id, Scope=scope)
-        return resp["WebACL"]
+        return c.get_web_acl(Name=name, Id=id, Scope=scope)
     except c.exceptions.WAFNonexistentItemException:
         return None
+
+
+def get_web_acl(
+    name: str,
+    id: str,
+    scope: str = "REGIONAL",
+):
+    """Returns just the WebACL object from the GetWebACL response."""
+    resp = get(name, id, scope)
+    if resp is None:
+        return None
+    return resp["WebACL"]


### PR DESCRIPTION
Issue [#2846](https://github.com/aws-controllers-k8s/community/issues/2846)

Description of changes:
Capacity and ApplicationIntegrationURL are readOnly fields returned by
Wafv2 during a GetWebACL call.

With these changes, we expose these fields in the ACK WebACL CRD status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
