### PR TITLE
fix[webACL]: populate status after updates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-04-04T00:09:13Z"
+  build_date: "2026-04-12T18:15:14Z"
   build_hash: a9e2ceaadfc00a742e2ea2b6d6c68348f03e52a5
   go_version: go1.26.0
   version: v0.58.0-3-ga9e2cea
@@ -7,7 +7,7 @@ api_directory_checksum: b76e1cbc62fb6cc6a9c5bd0fd0a1c31fd6c701c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: d67c506d08a923fb3690a1d7b1352f61332d63dc
+  file_checksum: f0586ed8dedc226bbee269b202b8b19640f5db34
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -137,5 +137,7 @@ resources:
         template_path: hooks/webacl/sdk_create_post_set_output.go.tpl
       sdk_update_post_build_request:
         template_path: hooks/webacl/sdk_update_post_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/webacl/sdk_update_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/common/sdk_file_end.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -137,5 +137,7 @@ resources:
         template_path: hooks/webacl/sdk_create_post_set_output.go.tpl
       sdk_update_post_build_request:
         template_path: hooks/webacl/sdk_update_post_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/webacl/sdk_update_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/common/sdk_file_end.go.tpl

--- a/pkg/resource/web_acl/hooks.go
+++ b/pkg/resource/web_acl/hooks.go
@@ -3,6 +3,8 @@ package web_acl
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/ghodss/yaml"
 
@@ -10,10 +12,15 @@ import (
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/wafv2"
 
 	svcapitypes "github.com/aws-controllers-k8s/wafv2-controller/apis/v1alpha1"
+)
+
+var (
+	updateRqueue = requeue.NeededAfter(fmt.Errorf("resource updated, requeing to sync webacl status"), time.Second)
 )
 
 type Statement interface {

--- a/pkg/resource/web_acl/sdk.go
+++ b/pkg/resource/web_acl/sdk.go
@@ -4380,6 +4380,8 @@ func (rm *resourceManager) sdkUpdate(
 	ko := desired.ko.DeepCopy()
 
 	rm.setStatusDefaults(ko)
+	return &resource{ko}, updateRqueue
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/webacl/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/webacl/sdk_update_post_set_output.go.tpl
@@ -1,0 +1,1 @@
+	return &resource{ko}, updateRqueue

--- a/test/e2e/tests/test_web_acl.py
+++ b/test/e2e/tests/test_web_acl.py
@@ -208,6 +208,11 @@ class TestWebACL:
         assert rules[0]["Name"] == "rule-3"
         assert description == "updated description"
 
+        # Verify capacity in ACK status matches AWS after update
+        cr = k8s.get_resource(ref)
+        assert "capacity" in cr["status"]
+        assert cr["status"]["capacity"] == latest["Capacity"]
+
         # delete the CR
         _, deleted = k8s.delete_custom_resource(ref, DELETE_WAIT_SECONDS)
         assert deleted


### PR DESCRIPTION
Issue [#2852](https://github.com/aws-controllers-k8s/community/issues/2852)

Description of changes:
Currently, when the WebACL resource is updated, the update API output
does not return anything so we can populate the resource status.

In this change, we are adding a reuque error after successful updates to
ensure the resource status gets populated from sdkFind.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
