### PR TITLE
Build controller with v0.59.1 runtime/code-gen changes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:21:26Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  build_date: "2026-05-27T16:42:38Z"
+  build_hash: d4db016091e4579dcbbfec59495c3856581a0b3f
   go_version: go1.26.2
-  version: v0.58.1
+  version: v0.59.1-3-gd4db016
 api_directory_checksum: b76e1cbc62fb6cc6a9c5bd0fd0a1c31fd6c701c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/wafv2.services.k8s.aws_ipsets.yaml
+++ b/config/crd/bases/wafv2.services.k8s.aws_ipsets.yaml
@@ -173,6 +173,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/config/crd/bases/wafv2.services.k8s.aws_rulegroups.yaml
+++ b/config/crd/bases/wafv2.services.k8s.aws_rulegroups.yaml
@@ -3797,6 +3797,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/config/crd/bases/wafv2.services.k8s.aws_webacls.yaml
+++ b/config/crd/bases/wafv2.services.k8s.aws_webacls.yaml
@@ -4336,6 +4336,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/wafv2-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/runtime v0.59.1
 	github.com/aws/aws-sdk-go v1.51.21
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.55.11
@@ -51,7 +51,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.59.1 h1:7UDKl9/dif8oNjxx/5Z5ciUfuyn86MS4BvoG9LqF6h4=
+github.com/aws-controllers-k8s/runtime v0.59.1/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.51.21 h1:UrT6JC9R9PkYYXDZBV0qDKTualMr+bfK2eboTknMgbs=
 github.com/aws/aws-sdk-go v1.51.21/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -110,8 +110,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/helm/crds/wafv2.services.k8s.aws_ipsets.yaml
+++ b/helm/crds/wafv2.services.k8s.aws_ipsets.yaml
@@ -173,6 +173,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/helm/crds/wafv2.services.k8s.aws_rulegroups.yaml
+++ b/helm/crds/wafv2.services.k8s.aws_rulegroups.yaml
@@ -3797,6 +3797,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/helm/crds/wafv2.services.k8s.aws_webacls.yaml
+++ b/helm/crds/wafv2.services.k8s.aws_webacls.yaml
@@ -4336,6 +4336,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/pkg/resource/ip_set/identifiers.go
+++ b/pkg/resource/ip_set/identifiers.go
@@ -53,3 +53,12 @@ func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
 	}
 	return nil
 }
+
+// Partition returns the AWS partition in which the reosurce exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Partition() *ackv1alpha1.AWSPartition {
+	if ri.meta != nil {
+		return ri.meta.Partition
+	}
+	return nil
+}

--- a/pkg/resource/ip_set/manager.go
+++ b/pkg/resource/ip_set/manager.go
@@ -75,6 +75,8 @@ type resourceManager struct {
 	awsAccountID ackv1alpha1.AWSAccountID
 	// The AWS Region that this resource manager targets
 	awsRegion ackv1alpha1.AWSRegion
+	// The AWS Partition that this resource manager targets
+	awsPartition ackv1alpha1.AWSPartition
 	// sdk is a pointer to the AWS service API client exposed by the
 	// aws-sdk-go-v2/services/{alias} package.
 	sdkapi *svcsdk.Client
@@ -193,7 +195,8 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:wafv2:%s:%s:%s",
+		"arn:%s:wafv2:%s:%s:%s",
+		rm.awsPartition,
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,
@@ -345,6 +348,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
+		awsPartition: ackv1alpha1.AWSPartition(cfg.Partition),
 		sdkapi:       svcsdk.NewFromConfig(clientcfg),
 	}, nil
 }

--- a/pkg/resource/ip_set/sdk.go
+++ b/pkg/resource/ip_set/sdk.go
@@ -379,6 +379,9 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.ACKResourceMetadata.Region == nil {
 		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
 	}
+	if ko.Status.ACKResourceMetadata.Partition == nil {
+		ko.Status.ACKResourceMetadata.Partition = &rm.awsPartition
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}

--- a/pkg/resource/rule_group/identifiers.go
+++ b/pkg/resource/rule_group/identifiers.go
@@ -53,3 +53,12 @@ func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
 	}
 	return nil
 }
+
+// Partition returns the AWS partition in which the reosurce exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Partition() *ackv1alpha1.AWSPartition {
+	if ri.meta != nil {
+		return ri.meta.Partition
+	}
+	return nil
+}

--- a/pkg/resource/rule_group/manager.go
+++ b/pkg/resource/rule_group/manager.go
@@ -75,6 +75,8 @@ type resourceManager struct {
 	awsAccountID ackv1alpha1.AWSAccountID
 	// The AWS Region that this resource manager targets
 	awsRegion ackv1alpha1.AWSRegion
+	// The AWS Partition that this resource manager targets
+	awsPartition ackv1alpha1.AWSPartition
 	// sdk is a pointer to the AWS service API client exposed by the
 	// aws-sdk-go-v2/services/{alias} package.
 	sdkapi *svcsdk.Client
@@ -193,7 +195,8 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:wafv2:%s:%s:%s",
+		"arn:%s:wafv2:%s:%s:%s",
+		rm.awsPartition,
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,
@@ -373,6 +376,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
+		awsPartition: ackv1alpha1.AWSPartition(cfg.Partition),
 		sdkapi:       svcsdk.NewFromConfig(clientcfg),
 	}, nil
 }

--- a/pkg/resource/rule_group/sdk.go
+++ b/pkg/resource/rule_group/sdk.go
@@ -6243,6 +6243,9 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.ACKResourceMetadata.Region == nil {
 		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
 	}
+	if ko.Status.ACKResourceMetadata.Partition == nil {
+		ko.Status.ACKResourceMetadata.Partition = &rm.awsPartition
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}

--- a/pkg/resource/web_acl/identifiers.go
+++ b/pkg/resource/web_acl/identifiers.go
@@ -53,3 +53,12 @@ func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
 	}
 	return nil
 }
+
+// Partition returns the AWS partition in which the reosurce exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Partition() *ackv1alpha1.AWSPartition {
+	if ri.meta != nil {
+		return ri.meta.Partition
+	}
+	return nil
+}

--- a/pkg/resource/web_acl/manager.go
+++ b/pkg/resource/web_acl/manager.go
@@ -75,6 +75,8 @@ type resourceManager struct {
 	awsAccountID ackv1alpha1.AWSAccountID
 	// The AWS Region that this resource manager targets
 	awsRegion ackv1alpha1.AWSRegion
+	// The AWS Partition that this resource manager targets
+	awsPartition ackv1alpha1.AWSPartition
 	// sdk is a pointer to the AWS service API client exposed by the
 	// aws-sdk-go-v2/services/{alias} package.
 	sdkapi *svcsdk.Client
@@ -193,7 +195,8 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:wafv2:%s:%s:%s",
+		"arn:%s:wafv2:%s:%s:%s",
+		rm.awsPartition,
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,
@@ -373,6 +376,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
+		awsPartition: ackv1alpha1.AWSPartition(cfg.Partition),
 		sdkapi:       svcsdk.NewFromConfig(clientcfg),
 	}, nil
 }

--- a/pkg/resource/web_acl/sdk.go
+++ b/pkg/resource/web_acl/sdk.go
@@ -6555,6 +6555,9 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.ACKResourceMetadata.Region == nil {
 		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
 	}
+	if ko.Status.ACKResourceMetadata.Partition == nil {
+		ko.Status.ACKResourceMetadata.Partition = &rm.awsPartition
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}


### PR DESCRIPTION
Issue #, if available: Fixes [2893](https://github.com/aws-controllers-k8s/community/issues/2893)

Description of changes:
Rebuild wafv2-controller with v0.59.1 codegen/runtime changes to add Partition resource status. Depends on code-generator PR [707](https://github.com/aws-controllers-k8s/code-generator/pull/707) to resolve issue with custom fields added to API shape shared by more than one resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
