### PR TITLE
fix(webacl): return created resource when logging sync fails

### DIFF
--- a/pkg/resource/web_acl/sdk.go
+++ b/pkg/resource/web_acl/sdk.go
@@ -2207,7 +2207,7 @@ func (rm *resourceManager) sdkCreate(
 	// After creation, sync the logging configuration if specified
 	if ko.Spec.LoggingConfiguration != nil {
 		if err = syncLoggingConfiguration(ctx, rm, &resource{ko}, nil); err != nil {
-			return nil, err
+			return &resource{ko}, err
 		}
 	}
 

--- a/templates/hooks/webacl/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/webacl/sdk_create_post_set_output.go.tpl
@@ -1,7 +1,7 @@
 	// After creation, sync the logging configuration if specified
 	if ko.Spec.LoggingConfiguration != nil {
 		if err = syncLoggingConfiguration(ctx, rm, &resource{ko}, nil); err != nil {
-			return nil, err
+			return &resource{ko}, err
 		}
 	}
 	


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2853

When creating a WebACL with LoggingConfiguration, if the primary WebACL is successfully created but the subsequent PutLoggingConfiguration call fails, the controller previously returned (nil, err). This caused the ACK runtime to assume the resource was not created in AWS, leading it to unmanage the resource and remove its finalizer. The WebACL was then orphaned in AWS.

By returning (&resource{ko}, err), the runtime receives the partially created resource's state (including its ARN and ID), preventing it from being unmanaged (with the recent runtime fixes) and allowing the controller to retry the logging sync on subsequent reconciliations.