### PR TITLE
fix: map WAFNonexistentItemException to 404 / ackerr.NotFound

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-27T16:42:38Z"
-  build_hash: d4db016091e4579dcbbfec59495c3856581a0b3f
-  go_version: go1.26.2
-  version: v0.59.1-3-gd4db016
+  build_date: "2026-06-05T18:30:08Z"
+  build_hash: 8d8f5f2406b145d2bf19f9bba75086b2445ffe4b
+  go_version: go1.25.0
+  version: v0.59.1-6-g8d8f5f2
 api_directory_checksum: b76e1cbc62fb6cc6a9c5bd0fd0a1c31fd6c701c1
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: f0586ed8dedc226bbee269b202b8b19640f5db34
+  file_checksum: ed952fe37707fdff756ba339e023a8a64c6e68cf
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,10 @@ operations:
     output_wrapper_field_path: WebACL
 resources:
   IPSet:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Name:
         is_primary_key: true
@@ -48,6 +52,10 @@ resources:
       sdk_read_one_post_set_output:
         template_path: hooks/ipset/sdk_read_one_post_set_output.go.tpl
   RuleGroup:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Name:
         is_primary_key: true
@@ -88,6 +96,10 @@ resources:
       sdk_file_end:
         template_path: hooks/common/sdk_file_end.go.tpl
   WebACL:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Capacity:
         is_read_only: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,10 @@ operations:
     output_wrapper_field_path: WebACL
 resources:
   IPSet:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Name:
         is_primary_key: true
@@ -48,6 +52,10 @@ resources:
       sdk_read_one_post_set_output:
         template_path: hooks/ipset/sdk_read_one_post_set_output.go.tpl
   RuleGroup:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Name:
         is_primary_key: true
@@ -88,6 +96,10 @@ resources:
       sdk_file_end:
         template_path: hooks/common/sdk_file_end.go.tpl
   WebACL:
+    exceptions:
+      errors:
+        404:
+          code: WAFNonexistentItemException
     fields:
       Capacity:
         is_read_only: true

--- a/pkg/resource/ip_set/sdk.go
+++ b/pkg/resource/ip_set/sdk.go
@@ -80,7 +80,7 @@ func (rm *resourceManager) sdkFind(
 	rm.metrics.RecordAPICall("READ_ONE", "GetIPSet", err)
 	if err != nil {
 		var awsErr smithy.APIError
-		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "UNKNOWN" {
+		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "WAFNonexistentItemException" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err

--- a/pkg/resource/rule_group/sdk.go
+++ b/pkg/resource/rule_group/sdk.go
@@ -87,7 +87,7 @@ func (rm *resourceManager) sdkFind(
 	rm.metrics.RecordAPICall("READ_ONE", "GetRuleGroup", err)
 	if err != nil {
 		var awsErr smithy.APIError
-		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "UNKNOWN" {
+		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "WAFNonexistentItemException" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err

--- a/pkg/resource/web_acl/sdk.go
+++ b/pkg/resource/web_acl/sdk.go
@@ -88,7 +88,7 @@ func (rm *resourceManager) sdkFind(
 	rm.metrics.RecordAPICall("READ_ONE", "GetWebACL", err)
 	if err != nil {
 		var awsErr smithy.APIError
-		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "UNKNOWN" {
+		if errors.As(err, &awsErr) && awsErr.ErrorCode() == "WAFNonexistentItemException" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#2911

`sdkFind` for all three wafv2 resources (`WebACL`, `IPSet`, `RuleGroup`) translated only the literal `"UNKNOWN"` error code to `ackerr.NotFound`. The real AWS not-found code is `WAFNonexistentItemException`, so when the underlying AWS resource is gone the controller never recognized it as missing — the runtime never received `ackerr.NotFound` during the delete path, the finalizer was never removed, and the CR sat in `Terminating` indefinitely with the controller hot-looping on the read API.

Adds `exceptions.errors.404.code: WAFNonexistentItemException` to each of the three resources in `generator.yaml`, and regenerates. The generated `sdkFind` in each `sdk.go` now compares against the real error code instead of the `"UNKNOWN"` placeholder.

Regenerated with `make build-controller SERVICE=wafv2` against `code-generator` at `v0.59.1-6-g8d8f5f2`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
